### PR TITLE
fix: Task list checkboxes now render and toggle properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "WYSIWYG markdown editor with live sync for AI collaboration",
   "version": "0.1.0",
   "publisher": "ajohnson",
-  "icon": "media/icon_z_broccoli.png",
+  "icon": "media/logo_motion.jpg",
   "repository": {
     "type": "git",
     "url": "https://github.com/austinbjohnson/defaultMarkdownRender"


### PR DESCRIPTION
Closes #20

## Problem
Task lists were not rendering as checkboxes:
- `//todo` and toolbar button created bullet lists instead
- Manually typing `- [ ]` didn't render as checkbox

## Solution
1. **Markdown Insertion**: `insertTaskList()` now inserts raw `- [ ] ` markdown text which Milkdown's GFM plugin parses correctly

2. **CSS Rendering**: Added custom CSS to render checkboxes using `::before` and `::after` pseudo-elements:
   - Targets `li[data-item-type="task"]` (Milkdown's GFM task list output)
   - Unchecked: Empty bordered box
   - Checked: Blue filled box with white checkmark + strikethrough text

3. **Click Toggle**: Added click handler that:
   - Detects clicks in the first 24px of task list items (checkbox area)
   - Toggles `data-checked` attribute
   - Syncs change back to VS Code document

## Testing
1. Install the VSIX
2. Type `//todo` and press Enter → should create a task list item with checkbox
3. Click the checkbox → should toggle checked state
4. Click toolbar ☐ button → should create task list
5. Manually type `- [ ] Test` → should render as checkbox

## Screenshots
Uses VS Code theme variables for checkbox styling (`--vscode-checkbox-*`).