### PR TITLE
feat: Add Obsidian-style frontmatter rendering

### DIFF
--- a/hello.md
+++ b/hello.md
@@ -1,3 +1,14 @@
+---
+title: Hello Document
+date: 2026-01-21
+author: ajohnson
+description: A sample markdown document for testing the VS Code plugin
+tags:
+  - markdown
+  - sample
+  - testing
+---
+
 # title
 
 this is a doc

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -198,6 +198,15 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     <div id="slash-menu-list"></div>
   </div>
   <div id="editor-container">
+    <!-- Frontmatter panel (hidden by default, shown only if frontmatter exists) -->
+    <div id="frontmatter-panel" class="frontmatter-panel" style="display: none;">
+      <div class="frontmatter-header" id="frontmatter-toggle">
+        <span class="frontmatter-chevron">▶</span>
+        <span class="frontmatter-title">Properties</span>
+        <span class="frontmatter-count" id="frontmatter-count"></span>
+      </div>
+      <div class="frontmatter-content" id="frontmatter-content"></div>
+    </div>
     <div id="editor"></div>
   </div>
   <script nonce="${nonce}" src="${scriptUri}"></script>

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -240,6 +240,171 @@ html, body {
 }
 
 /* ==========================================================================
+   Frontmatter Panel (Obsidian-style)
+   ========================================================================== */
+
+.frontmatter-panel {
+  max-width: 800px;
+  margin: 0 auto 16px auto;
+  background-color: var(--vscode-editor-inactiveSelectionBackground, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--vscode-editorWidget-border, #454545);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.frontmatter-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  cursor: pointer;
+  user-select: none;
+  background-color: var(--vscode-editorWidget-background, #252526);
+  border-bottom: 1px solid var(--vscode-editorWidget-border, #454545);
+  transition: background-color 0.15s ease;
+}
+
+.frontmatter-header:hover {
+  background-color: var(--vscode-list-hoverBackground, #2a2d2e);
+}
+
+.frontmatter-panel.collapsed .frontmatter-header {
+  border-bottom: none;
+}
+
+.frontmatter-chevron {
+  font-size: 10px;
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+  width: 14px;
+  text-align: center;
+  transition: transform 0.15s ease;
+}
+
+.frontmatter-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vscode-editor-foreground, #d4d4d4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.frontmatter-count {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+  margin-left: auto;
+}
+
+.frontmatter-content {
+  padding: 12px 14px;
+}
+
+/* Frontmatter rows */
+.fm-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(69, 69, 69, 0.5));
+}
+
+.fm-row:last-child {
+  border-bottom: none;
+}
+
+.fm-key {
+  min-width: 100px;
+  max-width: 140px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--vscode-textLink-foreground, #3794ff);
+  word-break: break-word;
+  flex-shrink: 0;
+}
+
+.fm-value {
+  flex: 1;
+  font-size: 13px;
+  font-family: var(--vscode-editor-font-family, 'Menlo', 'Monaco', 'Courier New', monospace);
+  color: var(--vscode-editor-foreground, #d4d4d4);
+  word-break: break-word;
+}
+
+/* Value type styling */
+.fm-string {
+  color: var(--vscode-editor-foreground, #d4d4d4);
+}
+
+.fm-number {
+  color: var(--vscode-debugTokenExpression-number, #b5cea8);
+}
+
+.fm-boolean {
+  color: var(--vscode-debugTokenExpression-boolean, #569cd6);
+}
+
+.fm-null {
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+  font-style: italic;
+}
+
+.fm-array-empty,
+.fm-object-empty {
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+}
+
+/* Multi-line strings */
+.fm-multiline {
+  background-color: var(--vscode-textCodeBlock-background, #2d2d2d);
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin-top: 4px;
+}
+
+.fm-multiline-line {
+  line-height: 1.5;
+  min-height: 1.5em;
+}
+
+/* Arrays */
+.fm-array {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fm-array-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.fm-array-item::before {
+  content: '•';
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+  font-size: 10px;
+}
+
+/* Nested objects */
+.fm-nested-object {
+  padding-left: 12px;
+  border-left: 2px solid var(--vscode-editorWidget-border, #454545);
+  margin-top: 4px;
+}
+
+.fm-nested-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.fm-nested-key {
+  font-size: 11px;
+  color: var(--vscode-textLink-foreground, #3794ff);
+  opacity: 0.8;
+}
+
+/* ==========================================================================
    Editor Container
    ========================================================================== */
 


### PR DESCRIPTION
## Summary

Implements Issue #22 - Adds Obsidian-style frontmatter rendering to the markdown editor.

## Changes

- **Added `gray-matter` dependency** to parse YAML frontmatter from markdown documents
- **Extract frontmatter** before initializing Milkdown, passing only body content to the editor
- **Frontmatter panel UI** with:
  - Collapsible header with property count
  - Key-value display for all frontmatter fields
  - Support for multi-line strings (preserves line breaks)
  - Support for arrays (rendered as bullet lists)
  - Support for nested objects
  - Styled with VS Code theme variables for dark/light mode compatibility
- **Smart handling for documents without frontmatter** - panel is hidden, no visual change
- **Sync on edit** - reconstructs full markdown (frontmatter + body) when sending changes to VS Code

## Screenshots

The frontmatter panel appears above the editor when a document has YAML frontmatter:

```yaml
---
title: My Document
tags:
  - feature
  - documentation
author: ajohnson
---
```

Documents without frontmatter display as normal - no panel, no visual change.

## Testing

1. Open a markdown file WITH frontmatter - verify panel appears with correct data
2. Open a markdown file WITHOUT frontmatter - verify no panel appears
3. Click the panel header to collapse/expand
4. Edit the document body - verify frontmatter is preserved in the saved file
5. External edits (e.g., from AI) - verify frontmatter panel updates correctly

Closes #22