### PR TITLE
feat: Configurable default view (rendered vs source)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,7 +6,9 @@ node_modules/**
 tsconfig.json
 esbuild.config.js
 **/*.map
-*.jpg
-*.jpeg
 hello.md
+# Exclude unused images but keep the extension icon
+media/icon_z_broccoli.png
+media/logo_motion.jpg
+media/zapier orange broccoli.jpg
 .claude/**

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "customEditors": [
@@ -28,22 +30,22 @@
             "filenamePattern": "*.md"
           }
         ],
-        "priority": "default"
+        "priority": "option"
       }
     ],
     "configuration": {
       "title": "Markdown Live Render",
       "properties": {
-        "markdownLiveRender.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable the live markdown renderer for this workspace"
+        "markdownLiveRender.defaultView": {
+          "type": "string",
+          "enum": ["rendered", "source"],
+          "enumDescriptions": [
+            "Open markdown files in the live rendered view (WYSIWYG editor)",
+            "Open markdown files as raw source text"
+          ],
+          "default": "rendered",
+          "description": "Choose how markdown files open by default. You can always switch views using Cmd+Shift+M (Mac) or Ctrl+Shift+M (Windows/Linux)."
         }
-      }
-    },
-    "configurationDefaults": {
-      "workbench.editorAssociations": {
-        "*.md": "markdownLiveRender.editor"
       }
     },
     "commands": [
@@ -58,6 +60,10 @@
       {
         "command": "markdownLiveRender.toggle",
         "title": "Toggle Markdown Rendered/Raw View"
+      },
+      {
+        "command": "markdownLiveRender.toggleDefaultView",
+        "title": "Markdown Live Render: Toggle Default View"
       }
     ],
     "keybindings": [


### PR DESCRIPTION
## Summary

Users can now choose whether markdown files open in rendered view or raw source text by default.

- **Settings UI**: Go to Settings > search "Markdown Live Render" > choose "rendered" or "source"
- **Command Palette**: Run "Markdown Live Render: Toggle Default View" to quickly switch
- **Keyboard shortcut**: Cmd+Shift+M still toggles the current file regardless of default

## Changes

- Add `defaultView` setting with clear "rendered" and "source" options
- Add command palette action to toggle the default
- Fix .vscodeignore so the extension icon is included in the package

## Test plan

- [ ] Set default to "rendered" → open a .md file → opens in rendered view
- [ ] Set default to "source" → open a .md file → opens in raw text
- [ ] Run "Markdown Live Render: Toggle Default View" → shows notification and changes default
- [ ] Cmd+Shift+M toggles current file regardless of default setting
- [ ] Extension icon shows correctly (not broccoli)

Closes #25