### PR TITLE
feat: add robust YAML frontmatter handling

### DIFF
--- a/hello-obsidian.md
+++ b/hello-obsidian.md
@@ -1,0 +1,32 @@
+---
+title: Obsidian Test Note
+aliases:
+  - Obsidian Hello
+  - YAML Render Check
+tags:
+  - notes
+  - obsidian
+  - frontmatter
+created: 2026-02-11
+updated: 2026-02-11T16:00:00Z
+cssclass: wide-page
+publish: false
+obsidian:
+  nested:
+    theme: dark
+    review:
+      required: true
+      owners:
+        - ajohnson
+        - ai-agent
+---
+
+# Hello Obsidian
+
+This file simulates a typical Obsidian-style frontmatter block.
+
+## Checklist
+
+- [ ] Open in Markdown Live Render
+- [ ] Make a small body edit
+- [ ] Save and confirm frontmatter is unchanged

--- a/hello-skill.md
+++ b/hello-skill.md
@@ -1,0 +1,14 @@
+---
+name: "hello-skill"
+description: "Test fixture for skill-style YAML frontmatter rendering and round-trip stability."
+---
+
+# Hello Skill
+
+This file mirrors the frontmatter shape used by SKILL.md files.
+
+## Expected Behavior
+
+1. Frontmatter panel appears and parses `name` and `description`.
+2. Editing markdown body does not mutate frontmatter.
+3. Reopening the file preserves exact frontmatter delimiters and values.

--- a/hello.md
+++ b/hello.md
@@ -1,24 +1,16 @@
-# title
+# Hello World
 
-this is a doc
+This file validates plain markdown rendering with no frontmatter.
 
-<br />
+## What Happens If I Do This
 
-## what happens if i do this
-
-<br />
-
-or just this
-
-<br />
+Regular markdown still renders in Milkdown.
 
 ## Haiku
 
 Soft morning mist falls\
 Cherry blossoms drift downstream\
 Spring awakens slow
-
-## Added by terminal
 
 ## Color Numbers
 
@@ -30,22 +22,4 @@ Spring awakens slow
 | Lavender  | 99     | #E6E6FA  |
 | Coral     | 56     | #FF7F50  |
 | Slate     | 23     | #708090  |
-
-Soft morning mist falls\
-Cherry blossoms drift downstream\
-Spring awakens slow
-
-<br />
-
-<br />
-
-| <br /> | <br /> | <br /> |
-| :----- | :----- | :----- |
-| <br /> | <br /> | <br /> |
-
-<br />
-
-<br />
-
-<br />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,11 @@
         "@milkdown/preset-gfm": "^7.3.6",
         "@milkdown/theme-nord": "^7.3.6",
         "@milkdown/utils": "^7.3.6",
-        "diff-match-patch": "^1.0.5"
+        "diff-match-patch": "^1.0.5",
+        "js-yaml": "^4.1.1"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.10.0",
         "@types/vscode": "^1.85.0",
         "@typescript-eslint/eslint-plugin": "^6.13.0",
@@ -768,6 +770,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1110,7 +1119,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -1953,7 +1961,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
       "properties": {
         "markdownLiveRender.defaultView": {
           "type": "string",
-          "enum": ["rendered", "source"],
+          "enum": [
+            "rendered",
+            "source"
+          ],
           "enumDescriptions": [
             "Open markdown files in the live rendered view (WYSIWYG editor)",
             "Open markdown files as raw source text"
@@ -82,6 +85,7 @@
     "lint": "eslint src --ext ts"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.10.0",
     "@types/vscode": "^1.85.0",
     "@typescript-eslint/eslint-plugin": "^6.13.0",
@@ -99,6 +103,7 @@
     "@milkdown/preset-gfm": "^7.3.6",
     "@milkdown/theme-nord": "^7.3.6",
     "@milkdown/utils": "^7.3.6",
-    "diff-match-patch": "^1.0.5"
+    "diff-match-patch": "^1.0.5",
+    "js-yaml": "^4.1.1"
   }
 }

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -196,6 +196,13 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   <div id="slash-menu" class="slash-menu" style="display: none;">
     <div id="slash-menu-list"></div>
   </div>
+  <div id="frontmatter-container" class="frontmatter-container" style="display: none;">
+    <div class="frontmatter-header" id="frontmatter-toggle">
+      <span class="frontmatter-chevron">▶</span>
+      <span class="frontmatter-label">Frontmatter</span>
+    </div>
+    <div class="frontmatter-content" id="frontmatter-content" style="display: none;"></div>
+  </div>
   <div id="editor-container">
     <div id="editor"></div>
   </div>

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -240,6 +240,148 @@ html, body {
 }
 
 /* ==========================================================================
+   Frontmatter Panel
+   ========================================================================== */
+
+.frontmatter-container {
+  margin: 10px 20px 0;
+  border: 1px solid var(--vscode-editorWidget-border, #454545);
+  border-radius: 6px;
+  background-color: var(--vscode-editorWidget-background, #252526);
+  overflow: hidden;
+}
+
+.frontmatter-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+  background-color: var(--vscode-sideBar-background, #252526);
+  border-bottom: 1px solid var(--vscode-editorWidget-border, #454545);
+}
+
+.frontmatter-header:hover {
+  background-color: var(--vscode-list-hoverBackground, #2a2d2e);
+}
+
+.frontmatter-chevron {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+  width: 10px;
+}
+
+.frontmatter-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vscode-editor-foreground, #d4d4d4);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.frontmatter-content {
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.frontmatter-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.frontmatter-property {
+  display: flex;
+  flex-direction: column;
+}
+
+.frontmatter-property-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-height: 20px;
+}
+
+.frontmatter-key {
+  color: var(--vscode-symbolIcon-propertyForeground, #9cdcfe);
+  font-weight: 600;
+}
+
+.frontmatter-separator {
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+  margin-right: 2px;
+}
+
+.frontmatter-value {
+  color: var(--vscode-editor-foreground, #d4d4d4);
+  overflow-wrap: anywhere;
+}
+
+.frontmatter-scalar {
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.frontmatter-scalar.is-number {
+  color: var(--vscode-debugTokenExpression-number, #b5cea8);
+}
+
+.frontmatter-scalar.is-boolean {
+  color: var(--vscode-debugTokenExpression-boolean, #569cd6);
+}
+
+.frontmatter-scalar.is-null {
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+  font-style: italic;
+}
+
+.frontmatter-scalar.is-date {
+  color: var(--vscode-debugTokenExpression-string, #ce9178);
+}
+
+.frontmatter-children {
+  margin-left: 16px;
+  border-left: 1px dashed var(--vscode-editorWidget-border, #454545);
+  padding-left: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.frontmatter-array-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.frontmatter-bullet {
+  color: var(--vscode-symbolIcon-arrayForeground, #c586c0);
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.frontmatter-array-value {
+  flex: 1;
+  min-width: 0;
+}
+
+.frontmatter-empty {
+  color: var(--vscode-descriptionForeground, #9d9d9d);
+  font-style: italic;
+}
+
+.depth-0 { margin-left: 0; }
+.depth-1 { margin-left: 8px; }
+.depth-2 { margin-left: 16px; }
+.depth-3 { margin-left: 24px; }
+.depth-4 { margin-left: 32px; }
+.depth-5 { margin-left: 40px; }
+.depth-6 { margin-left: 48px; }
+
+/* ==========================================================================
    Editor Container
    ========================================================================== */
 


### PR DESCRIPTION
## Summary
- add robust YAML frontmatter extraction/validation/preservation in the webview editor so frontmatter is not passed through Milkdown
- render frontmatter in a collapsible Obsidian-style panel with nested object/array/scalar support
- add/refresh markdown fixtures for plain markdown, Obsidian-style frontmatter, and skill-style frontmatter validation

## Test plan
- [x] `npm run build`
- [x] open `hello.md` and confirm plain markdown renders without frontmatter panel
- [x] open `hello-obsidian.md` and confirm nested frontmatter renders in the panel
- [x] open `hello-skill.md` and confirm skill frontmatter renders correctly
- [x] edit body content and verify frontmatter remains unchanged across save/reopen

Made with [Cursor](https://cursor.com)